### PR TITLE
Remove "(default: left)" in the description of copy-image

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,7 +59,7 @@ impl Cli {
         options.optflagopt(
             SHORT_NAME_COPY_IMAGE_AS_BASE,
             "copy-image",
-            "Copies specific image to output as base. (default: left)",
+            "Copies specific image to output as base.",
             "{left, right}",
         );
 


### PR DESCRIPTION
Closes #20 